### PR TITLE
Reduce the font size in citations

### DIFF
--- a/Sources/LLMStream/Configuration/ColorConfiguration.swift
+++ b/Sources/LLMStream/Configuration/ColorConfiguration.swift
@@ -26,6 +26,7 @@ public struct ColorConfiguration {
     public var citationHoverBackgroundColor: Color
     public var citationTextColor: Color
     public var citationHoverTextColor: Color
+    public var citationFontSizeRatio: Double
     
     public init(
         textColor: Color = .white,
@@ -43,7 +44,8 @@ public struct ColorConfiguration {
         citationBackgroundColor: Color = Color(red: 0.15, green: 0.15, blue: 0.15),
         citationHoverBackgroundColor: Color = Color(red: 0.15, green: 0.15, blue: 0.15),
         citationTextColor: Color = .white,
-        citationHoverTextColor: Color = .white
+        citationHoverTextColor: Color = .white,
+        citationFontSizeRatio: Double = 0.8
     ) {
         self.textColor = textColor
         self.backgroundColor = backgroundColor
@@ -61,5 +63,6 @@ public struct ColorConfiguration {
         self.citationHoverBackgroundColor = citationHoverBackgroundColor
         self.citationTextColor = citationTextColor
         self.citationHoverTextColor = citationHoverTextColor
+        self.citationFontSizeRatio = citationFontSizeRatio
     }
 }

--- a/Sources/LLMStream/MarkdownLatexView.swift
+++ b/Sources/LLMStream/MarkdownLatexView.swift
@@ -132,6 +132,7 @@ private extension MarkdownLatexViewShared {
             --code-font-family: \(configuration.font.codeFontFamily);
             --table-font-family: \(configuration.font.tableFontFamily);
             --math-font-family: \(configuration.font.mathFontFamily);
+            --citation-font-size: \(Int(configuration.font.size * configuration.colors.citationFontSizeRatio))px;
             
             /* Color Configuration */
             --text-color: \(configuration.colors.textColor.cssString);

--- a/Sources/LLMStream/Resources/markdownLatexStyle.css
+++ b/Sources/LLMStream/Resources/markdownLatexStyle.css
@@ -409,7 +409,7 @@ u {
     padding: var(--citation-padding);
     margin: var(--citation-margin);
     cursor: pointer;
-    font-size: var(--font-size);
+    font-size: var(--citation-font-size);
     position: relative;
     text-decoration: none;
     color: var(--citation-text-color);


### PR DESCRIPTION
Pretty self-explanatory. This PR reduces the size of the font for citations. Instead of hardcoding a value, I made it a ratio relative to the standard font size, to make it dynamic to user inputs. I'm defaulting this to 0.8, which gives us 12px font on our default 15px font. 

<img width="374" alt="Screenshot 2025-03-28 at 5 45 05 PM" src="https://github.com/user-attachments/assets/2862d8e6-af68-4df6-a01d-1bf9a72d9569" />
