### PR TITLE
Convert to plain text on copy events

### DIFF
--- a/Sources/LLMStream/Resources/markdownLatexScript.js
+++ b/Sources/LLMStream/Resources/markdownLatexScript.js
@@ -2,6 +2,16 @@ window.markdownContent = window.markdownContent || "";
 window.lastProcessedContent = window.lastProcessedContent || "";
 let md;
 
+// Add a global copy event handler to force plain text copy
+window.addEventListener('copy', function(e) {
+    const selection = window.getSelection();
+    if (!selection) return;
+    const text = selection.toString();
+    // Set clipboard data to plain text only
+    e.clipboardData.setData('text/plain', text);
+    e.preventDefault(); // Prevent default copy behavior (which includes HTML)
+});
+
 function updateHeight() {
     let height = document.documentElement.scrollHeight;
 


### PR DESCRIPTION
I’ve been experiencing an issue with Onit due to its dark color scheme and white text. When I generate text and copy it to paste into another application, such as Gmail, the text retains its white color. As a result, the pasted text is not visible:

Before: 

https://github.com/user-attachments/assets/3267ad2d-6705-4dd6-9465-931c6c4fefee


I've experienced this issue before in other apps (like copying from Notes into Slack or Email), and it's always driven me nuts. Now that it's in _my_  app, I feel a strong moral obligation to fix it. So, that's what we do in this PR. With this change, we listen for copy events, and then set the copied text to be plain text. This will provide a much better user experience. 

After: 
https://github.com/user-attachments/assets/9143723e-a5d6-47f4-98fe-de2c94159c0a

Note: we may want to update this logic later to leave certain types of edits, like boldened or italicized text, while removing other properties, like fonts or colors. 
