### PR TITLE
Fix iOS compilation error: NSWorkspace not available on iOS

### DIFF
--- a/Example/.gitignore
+++ b/Example/.gitignore
@@ -1,0 +1,2 @@
+.build/
+*.xcodeproj

--- a/Example/LLMStreamExample/ContentView.swift
+++ b/Example/LLMStreamExample/ContentView.swift
@@ -1,0 +1,82 @@
+//
+//  ContentView.swift
+//  LLMStreamExample
+//
+//  Created by Kévin Naudin on 14/03/2026.
+//
+
+import SwiftUI
+import LLMStream
+
+struct ContentView: View {
+    private let sampleMarkdown = """
+    # LLMStream iOS Example
+
+    This is a **test** of the `LLMStream` library on iOS.
+
+    ## Markdown Features
+
+    - **Bold text** and *italic text*
+    - `Inline code` support
+    - [Link to Apple](https://www.apple.com)
+
+    ## Code Block
+
+    ```swift
+    struct HelloWorld: View {
+        var body: some View {
+            Text("Hello, World!")
+        }
+    }
+    ```
+
+    ## LaTeX Support
+
+    Inline math: $E = mc^2$
+
+    Block math:
+
+    $$\\int_{0}^{\\infty} e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}$$
+
+    ## Table
+
+    | Feature | Status |
+    |---------|--------|
+    | Markdown | Supported |
+    | LaTeX | Supported |
+    | Links | Supported |
+    | Code blocks | Supported |
+
+    <think>
+    This is an example of a thought process block that can be collapsed.
+    The LLM is "thinking" here before providing its answer.
+    </think>
+
+    The answer after the thought process is **42**.
+    """
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                LLMStreamView(
+                    text: sampleMarkdown,
+                    onUrlClicked: { url in
+                        guard let url = URL(string: url) else { return }
+                        UIApplication.shared.open(url)
+                    }
+                )
+            }
+            .background(Color.black)
+            .navigationTitle("LLMStream")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbarBackground(Color.black, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
+        }
+        .preferredColorScheme(.dark)
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Example/LLMStreamExample/LLMStreamExampleApp.swift
+++ b/Example/LLMStreamExample/LLMStreamExampleApp.swift
@@ -1,0 +1,17 @@
+//
+//  LLMStreamExampleApp.swift
+//  LLMStreamExample
+//
+//  Created by Kévin Naudin on 14/03/2026.
+//
+
+import SwiftUI
+
+@main
+struct LLMStreamExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Example/project.yml
+++ b/Example/project.yml
@@ -1,0 +1,28 @@
+name: LLMStreamExample
+options:
+  bundleIdPrefix: com.synthinc
+  deploymentTarget:
+    iOS: "16.0"
+  xcodeVersion: "16.0"
+
+packages:
+  LLMStream:
+    path: ../
+
+targets:
+  LLMStreamExample:
+    type: application
+    platform: iOS
+    sources:
+      - LLMStreamExample
+    dependencies:
+      - package: LLMStream
+    settings:
+      base:
+        GENERATE_INFOPLIST_FILE: YES
+        INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
+        INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: YES
+        INFOPLIST_KEY_UILaunchScreen_Generation: YES
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        SWIFT_VERSION: "6.0"

--- a/Sources/LLMStream/MarkdownLatexView.swift
+++ b/Sources/LLMStream/MarkdownLatexView.swift
@@ -325,28 +325,35 @@ public class Coordinator: NSObject, WKScriptMessageHandler, WKNavigationDelegate
             webView.evaluateJavaScript("updateHeight();")
         }
     }
-    
+
     public func webView(_ webView: WKWebView,
                         decidePolicyFor navigationAction: WKNavigationAction,
-                        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-
+                        decisionHandler: @escaping @MainActor @Sendable (WKNavigationActionPolicy) -> Void) {
         if let url = navigationAction.request.url,
            navigationAction.navigationType == .linkActivated {
+            #if os(macOS)
             NSWorkspace.shared.open(url)
+            #else
+            UIApplication.shared.open(url)
+            #endif
             decisionHandler(.cancel)
         } else {
             decisionHandler(.allow)
         }
     }
-    
+
+
     public func webView(_ webView: WKWebView,
                         createWebViewWith configuration: WKWebViewConfiguration,
                         for navigationAction: WKNavigationAction,
                         windowFeatures: WKWindowFeatures) -> WKWebView? {
         if let url = navigationAction.request.url {
+            #if os(macOS)
             NSWorkspace.shared.open(url)
+            #else
+            UIApplication.shared.open(url)
+            #endif
         }
-        
         return nil
     }
 }


### PR DESCRIPTION
## Summary
- Add platform-conditional WKNavigationDelegate methods (`decidePolicyFor`, `createWebViewWith`) to the `Coordinator` class using `NSWorkspace` on macOS and `UIApplication` on iOS for URL handling
- Add Example iOS app with xcodegen project to test the library on the simulator

## Test plan
- [x] Build succeeds for iOS Simulator target
- [x] Build succeeds for macOS target
- [x] Example app runs on iPhone 17 Pro Simulator with correct rendering (markdown, code blocks, LaTeX, links, tables)

Closes #5